### PR TITLE
Options controls screen

### DIFF
--- a/tartarus_Compound/ProjectSettings/TagManager.asset
+++ b/tartarus_Compound/ProjectSettings/TagManager.asset
@@ -20,6 +20,7 @@ TagManager:
   - Trap
   - Terminal
   - RespawnPlatforms
+  - FallingPoint
   layers:
   - Default
   - TransparentFX
@@ -68,4 +69,7 @@ TagManager:
     locked: 0
   - name: Terrain
     uniqueID: 3161110929
+    locked: 0
+  - name: Foreground
+    uniqueID: 1569291711
     locked: 0


### PR DESCRIPTION
Screen that shows the game's control buttons
- keyboard only
- could use more graphics

DeathPit tilemap is moved to foreground, so that the player fall "into" it